### PR TITLE
Fix whitespace around LaTeX environments

### DIFF
--- a/R/thesis.R
+++ b/R/thesis.R
@@ -26,6 +26,10 @@ thesis_pdf <- function(toc = TRUE, toc_depth = 3, ...){
   base$knitr$opts_chunk$comment <- NA
   #base$knitr$opts_chunk$fig.align <- "center"
 
+  old_opt <- getOption("bookdown.post.latex")
+  options(bookdown.post.latex = fix_envs)
+  on.exit(options(bookdown.post.late = old_opt))
+
   base
 
 }
@@ -105,4 +109,16 @@ thesis_epub <- function(...){
 
   base
 
+}
+
+fix_envs = function(x){
+  beg_reg <- '^\\s*\\\\begin\\{.*\\}'
+  end_reg <- '^\\s*\\\\end\\{.*\\}'
+  i3 = if (length(i1 <- grep(beg_reg, x))) (i1 - 1)[grepl("^\\s*$", x[i1 - 1])]
+
+  i3 = c(i3,
+         if (length(i2 <- grep(end_reg, x))) (i2 + 1)[grepl("^\\s*$", x[i2 + 1])]
+  )
+  if (length(i3)) x = x[-i3]
+  x
 }


### PR DESCRIPTION
rstudio/bookdown@3e9ac3c7ea54009391b92b8ac9a14af1d328ebce gave the option to specify a post processing function for bookdown LaTeX output instead of implementing my solution across the board. I've made it the default in `thesisdown`.

Yihui pointed out the issue of users wanting to place environments in their own paragraph. That can still be done using the `\par` command.

This requires the development version of `bookdown`.