### PR TITLE
Code protruding outside the left margin

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/reedthesis.cls
+++ b/inst/rmarkdown/templates/thesis/skeleton/reedthesis.cls
@@ -59,7 +59,7 @@
 \newcommand{\VerbBar}{|}
 \newcommand{\VERB}{\Verb[commandchars=\\\{\}]}
 \DefineVerbatimEnvironment{verbatim}{Verbatim}{xleftmargin=-1em}
-\DefineVerbatimEnvironment{Highlighting}{Verbatim}{xleftmargin=-1em,commandchars=\\\{\}}
+\DefineVerbatimEnvironment{Highlighting}{Verbatim}{commandchars=\\\{\}}
 % Add ',fontsize=\small' for more characters per line
 \usepackage{framed}
 \definecolor{shadecolor}{RGB}{248,248,248}


### PR DESCRIPTION
1em was subtracted from the left margin in two different places, so code blocks had text hanging outside the shaded area. I deleted the second one.