### PR TITLE
Add \markboth in References

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/99-references.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/99-references.Rmd
@@ -10,7 +10,10 @@ delete "References" and replace it.
 -->
 
 # References {-}
-
+<!--
+This manually sets the header for this unnumbered chapter.
+-->
+\markboth{References}{References}
 <!--
 To remove the indentation of the first entry.
 -->


### PR DESCRIPTION
LaTeX won't automatically change the heading for unnumbered chapters, so you have to do it manually.