### PR TITLE
Fixes pandoc 2.0 chapters flag.

### DIFF
--- a/R/thesis.R
+++ b/R/thesis.R
@@ -20,7 +20,7 @@ thesis_pdf <- function(toc = TRUE, toc_depth = 3, highlight = "default", ...){
     toc_depth = toc_depth,
     highlight = highlight,
     keep_tex = TRUE,
-    pandoc_args = "--chapters",
+    pandoc_args = "--top-level-division=chapter",
     ...)
 
   # Mostly copied from knitr::render_sweave


### PR DESCRIPTION
Error message: 
```sh
--chapters has been removed. Use --top-level-division=chapter instead.
Try pandoc --help for more information.
Error: pandoc document conversion failed with error 2
Please delete _main.Rmd after you finish debugging the error.
Execution halted
```

Gitbook works fine.