### PR TITLE
Pandoc version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,4 +19,5 @@ Depends:
 License: MIT
 Encoding: UTF-8
 LazyData: true
+SystemRequirements: pandoc (>= 1.18) - http://pandoc.org
 RoxygenNote: 6.0.1

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Using **thesisdown** has some prerequisites which are described below. To compil
 To use **thesisdown** from RStudio:
 
 1) Install the latest [RStudio](http://www.rstudio.com/products/rstudio/download/).
+Only the version as of Oct 2017 has a recent enough Pandoc included so you may need to upgrade this
+separately or install a newer RStudio.
+
+    ```r
+    rmarkdown::pandoc_available("1.18")
+    #> [1] TRUE
+    ```
 
 2) Install the **bookdown** and **thesisdown** packages: 
 


### PR DESCRIPTION
Requirement to upgrade Pandoc
Only the version of RStudio released last month has a new enough version of Pandoc

Required due to change in ismayc/thesisdown#34