### PR TITLE
Skeleton.rmd: update line number references, minor arrangement edits,  wordsmithing

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -4,8 +4,8 @@ date: 'May 20xx'
 institution: 'Reed College'
 division: 'Mathematics and Natural Sciences'
 advisor: 'Advisor F. Name'
+# If you have more two advisors, un-silence line 7
 #altadvisor: 'Your Other Advisor'
-# Delete line 6 if you only have one advisor
 department: 'Mathematics'
 degree: 'Bachelor of Arts'
 title: 'My Final College Paper'
@@ -16,14 +16,13 @@ output:
   thesisdown::thesis_gitbook: default
 #  thesisdown::thesis_word: default
 #  thesisdown::thesis_epub: default
-# If you are creating a PDF you'll need to write your preliminary content here or
-# use code similar to line 20 for the files.  If you are producing in a different
-# format than PDF, you can delete or ignore lines 20-31 in this YAML header.
+# If you are creating a PDF you'll need to write your preliminary content (e.g., abstract, acknowledgements) here or
+# use code similar to line 22-23 for the .RMD files. If you are NOT producing a PDF, you can delete or silence lines 21-32 in this YAML header.
 abstract: |
   `r if(knitr:::is_latex_output()) paste(readLines("00-abstract.Rmd"), collapse = '\n  ')`
 # If you'd rather include the preliminary content in files instead of inline
 # like below, use a command like that for the abstract above.  Note that a tab is 
-# needed on the line after the |.
+# needed on the line after the `|`.
 acknowledgements: |
   I want to thank a few people.
 dedication: |
@@ -31,15 +30,13 @@ dedication: |
 preface: |
   This is an example of a thesis setup to use the reed thesis document class
   (for LaTeX) and the R bookdown package, in general.
+# Specify the location of the bibliography below
 bibliography: bib/thesis.bib
-# Download your specific bibliography database file and refer to it in the line above.
+# Download your specific csl file and refer to it in the line below.
 csl: csl/apa.csl
-# Download your specific csl file and refer to it in the line above.
 lot: true
 lof: true
-#space_between_paragraphs: true
-# Delete the # at the beginning of the previous line if you'd like
-# to have a blank new line between each paragraph
+# If you prefer blank lines between paragraphs, un-silence lines  40-41 (this requires package tikz)
 #header-includes:
 #- \usepackage{tikz}
 ---
@@ -47,12 +44,12 @@ lof: true
 <!--
 Above is the YAML (YAML Ain't Markup Language) header that includes a lot of metadata used to produce the document.  Be careful with spacing in this header!
 
-If you'd prefer to not include a Dedication, for example, simply delete lines 17 and 18 above or add a # before them to comment them out.  If you have other LaTeX packages you would like to include, delete the # before header-includes and list the packages after hyphens on new lines.
+If you'd prefer to not include a Dedication, for example, simply delete the section entirely, or silence (add #) them. 
+
+If you have other LaTeX packages you would like to include, delete the # before header-includes and list the packages after hyphens on new lines.
 
 If you'd like to include a comment that won't be produced in your resulting file enclose it in a block like this.
--->
 
-<!--
 If you receive a duplicate label error after knitting, make sure to delete the index.Rmd file and then knit again.
 -->
 
@@ -67,9 +64,12 @@ if(!require(thesisdown))
 library(thesisdown)
 ```
 
-<!-- You'll need to include the order that you'd like Rmd files to appear in the _bookdown.yml file for
-PDF files and also delete the # before rmd_files: there.  You'll want to not include 00(two-hyphens)prelim.Rmd
-and 00-abstract.Rmd since they are handled in the YAML above differently for the PDF version.
+<!-- On ordering the chapter files:
+There are two options:
+1. Name your chapter files in the order in which you want them to appear (e.g., 01-Inro, 02-Data, 03-Conclusions). 
+2. Otherwise, you can specify the order in which they appear in the _bookdown.yml (for PDF only).
+
+Do not include 00(two-hyphens)prelim.Rmd and 00-abstract.Rmd in the YAML file--they are handled in the YAML above differently for the PDF version.
 -->
 
 <!-- The {.unnumbered} option here means that the introduction will be "Chapter 0." You can also use {-} for no numbers
@@ -97,3 +97,6 @@ Having your code and commentary all together in one place has a plethora of bene
 **Who should use it?**
 
 Anyone who needs to use data analysis, math, tables, a lot of figures, complex cross-references, or who just cares about the final appearance of their document should use _R Markdown_. Of particular use should be anyone in the sciences, but the user-friendly nature of _Markdown_ and its ability to keep track of and easily include figures, automatically generate a table of contents, index, references, table of figures, etc. should make it of great benefit to nearly anyone writing a thesis project.
+
+**For additional help with bookdown** 
+Please visit [the free online bookdown reference guide](https://bookdown.org/yihui/bookdown/).


### PR DESCRIPTION
Moved silenced descriptions to above the line(s) to which they refer (e.g., line 33 refers to line 34).

Updated line number references. 

Also added yihue's bookdown gitbook as a resource (lines 101-102)