### PR TITLE
Added in cslreferences environment

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -113,6 +113,16 @@ $endif$
 }
 \makeatother
 
+%Added by @MyKo101, code provided by @GerbrichFerdinands
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+$endif$
+
 \renewcommand{\contentsname}{Table of Contents}
 % End of CII addition
 


### PR DESCRIPTION
Added code to the template.tex file to combat the update to Pandoc 2.8 requiring a cslreference environment to be defined