### PR TITLE
Add link to amsterdown pkg in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Have you created a thesisdown template for your institution and would like to ha
 |TU Wien                                 |[ben-schwen/robotdown](https://github.com/ben-schwen/robotdown)                               |[ismayc/thesisdown](https://github.com/ismayc/thesisdown)       |
 |University of Bristol                                 |[mattlee821/bristolthesis](https://github.com/mattlee821/bristolthesis)                               |[ismayc/thesisdown](https://github.com/ismayc/thesisdown)       |
 |Universidade Federal de Santa Catarina  | [lfpdroubi/ufscdown](https://github.com/lfpdroubi/ufscdown)                                  |[ismayc/thesisdown](https://github.com/ismayc/thesisdown)       |
+|Universiteit van Amsterdam              | [lcreteig/amsterdown](https://github.com/lcreteig/amsterdown)                                |[benmarwick/huskydown](https://github.com/benmarwick/huskydown) |
 
 ### Using thesisdown from Chester's GitHub
 


### PR DESCRIPTION
Thanks so much for creating `thesisdown`! It (together with `huskydown`) inspired me to create a template for the University of Amsterdam: `amsterdown`. This change adds a link to `amsterdown` in README.md.