### PR TITLE
Allow user to change bookdown::gitbook() options

### DIFF
--- a/R/thesis.R
+++ b/R/thesis.R
@@ -58,7 +58,7 @@ thesis_gitbook <- function(...){
     config = list(toc = list(collapse = "section",
       before = '<li><a href="./"></a></li>',
       after = '<li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>',
-      ...)
+      ...), ...
     )
   )
 

--- a/R/thesis.R
+++ b/R/thesis.R
@@ -53,12 +53,26 @@ thesis_pdf <- function(toc = TRUE, toc_depth = 3, highlight = "default", ...){
 #' }
 thesis_gitbook <- function(...){
 
+  before <- '<li><a href="./"></a></li>'
+  after <- '<li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>'
+
+  if ("toc" %in% names(list(...))) {
+    if ("before" %in% names(list(...)$toc)) {
+      before <- list(...)$toc$before
+    }
+    if ("after" %in% names(list(...)$toc)) {
+      after <- list(...)$toc$after
+    }
+  }
+
   base <- bookdown::gitbook(
     split_by = "chapter+number",
-    config = list(toc = list(collapse = "section",
-      before = '<li><a href="./"></a></li>',
-      after = '<li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>',
-      ...), ...
+    config = list(
+      toc = list(collapse = "section",
+                 before = before,
+                 after = after, ...
+                 ),
+      ...
     )
   )
 

--- a/R/thesis.R
+++ b/R/thesis.R
@@ -53,28 +53,36 @@ thesis_pdf <- function(toc = TRUE, toc_depth = 3, highlight = "default", ...){
 #' }
 thesis_gitbook <- function(...){
 
-  before <- '<li><a href="./"></a></li>'
-  after <- '<li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>'
+  config_default <- list(
+    toc = list(collapse = "section",
+               before = '<li><a href="./"></a></li>',
+               after = '<li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>'))
 
-  if ("toc" %in% names(list(...))) {
-    if ("before" %in% names(list(...)$toc)) {
-      before <- list(...)$toc$before
-    }
-    if ("after" %in% names(list(...)$toc)) {
-      after <- list(...)$toc$after
+  listarg <- list(...)
+
+  if (!"split_by" %in% names(listarg)) {
+    listarg$split_by <- "chapter+number"
+  }
+
+  if (!"config" %in% names(listarg)) {
+    listarg$config <- config_default
+  } else {
+    if (!"toc" %in% names(listarg$config)) {
+      listarg$config$toc <- config_default$toc
+    } else {
+      if (!"collapse" %in% names(listarg$config$toc)) {
+        listarg$config$toc$collapse <- config_default$toc$collapse
+      }
+      if (!"before" %in% names(listarg$config$toc)) {
+        listarg$config$toc$before <- config_default$toc$before
+      }
+      if (!"after" %in% names(listarg$config$toc)) {
+        listarg$config$toc$after <- config_default$toc$after
+      }
     }
   }
 
-  base <- bookdown::gitbook(
-    split_by = "chapter+number",
-    config = list(
-      toc = list(collapse = "section",
-                 before = before,
-                 after = after, ...
-                 ),
-      ...
-    )
-  )
+  base <- do.call(bookdown::gitbook, listarg)
 
   # Mostly copied from knitr::render_sweave
   base$knitr$opts_chunk$comment <- NA


### PR DESCRIPTION
With ellipsis here and the check of toc sub-options, YAML configuration like these will be passed to `bookdown::gitbook` correctly. 

```
thesisdown::thesis_gitbook: 
  sharing:
    facebook: no
    github: yes
  toc: 
    before: "<center><b><a href='./'>My super title</a></b></center>"
    after: null
```

Note: it's a better version of my last PR, you can ignore it. 
Note 2: it does not take into account other toc sub-options like `scroll_highlight`. 