### PR TITLE
[fix] packages were not loaded in the skeleton

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/01-chap1.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/01-chap1.Rmd
@@ -126,8 +126,10 @@ new.pkg <- pkg[!(pkg %in% installed.packages())]
 if (length(new.pkg)) {
   install.packages(new.pkg, repos = "https://cran.rstudio.com")
 }
-# Load packages (thesisdown will load all of the packages as well)
+# Load packages
 library(thesisdown)
+# load other packages
+invisible(lapply(pkg, library, character.only = T))
 ```
 
 \clearpage


### PR DESCRIPTION
since [the "Depends" changed to "Import"](https://github.com/ismayc/thesisdown/commit/2a39610b8f3a97974d9220976edb1d14cd74d6e5#diff-35ba4a2677442e210c23a00a5601aba3R14), the packages are not attached anymore to the environment and as the result Knitting was facing some errors.