### PR TITLE
Removing an extra page after "Preface" when TOC depth is bigger than 3

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -186,7 +186,7 @@ $endif$
 
 $if(toc)$
   \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
-  \setcounter{secnumdepth}{$toc-depth$ - 1}
+  \setcounter{secnumdepth}{$toc-depth$}
   \setcounter{tocdepth}{$toc-depth$}
   \tableofcontents
 $endif$


### PR DESCRIPTION
This "-1" add an extra empty page after "Preface". By removing it this page disappears and TOC depth / TOC num depth seem to be correct.