### PR TITLE
uncomment lines

### DIFF
--- a/R/thesis.R
+++ b/R/thesis.R
@@ -34,9 +34,9 @@ thesis_pdf <- function(toc = TRUE, toc_depth = 3, highlight = "default", ...) {
   base$knitr$opts_chunk$comment <- NA
   # base$knitr$opts_chunk$fig.align <- "center"
 
-  # old_opt <- getOption("bookdown.post.latex")
-  # options(bookdown.post.latex = fix_envs)
-  # on.exit(options(bookdown.post.late = old_opt))
+  old_opt <- getOption("bookdown.post.latex")
+  options(bookdown.post.latex = fix_envs)
+  on.exit(options(bookdown.post.late = old_opt))
 
   base
 }


### PR DESCRIPTION
In your pull request #117, you commented this three lines 
```
  old_opt <- getOption("bookdown.post.latex")
  options(bookdown.post.latex = fix_envs)
  on.exit(options(bookdown.post.late = old_opt))
```
which causes the broke of both my local and remote (on GitHub Action) with this uninformative error:
```
! LaTeX Error: There's no line here to end.
Error: Error: LaTeX failed to compile thesis.tex. See https://yihui.org/tinytex/r/#debugging for debugging tips. See thesis.log for more info.
```

Actually, I don't understand what these lines do. But uncommenting them fixed my issue. 

Thanks!