### PR TITLE
Add an optional list of abbreviations

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -45,6 +45,14 @@ dedication: |
 preface: |
   This is an example of a thesis setup to use the reed thesis document class 
   (for LaTeX) and the R bookdown package, in general.
+abbreviations:
+  ABC: American Broadcasting Company
+  CBS: Colombia Broadcasting System
+  CUS: Computer User Services
+  PBS: Public Broadcasting System
+  NBC: National Broadcasting Company
+# Note that abbreviations in lowercase letters will NOT be automatically capitalized
+# Delete or silence the abbreviations section if you do not want a list of abbreviations
   
 # Specify the location of the bibliography below
 bibliography: bib/thesis.bib

--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -207,6 +207,18 @@ $if(preface)$
   \end{preface}
 $endif$
 
+$if(abbreviations)$
+\chapter*{List of Abbreviations}
+\begin{table}[h]
+    \centering
+    \begin{tabular}{ll}
+        $for(abbreviations/pairs)$
+        \textbf{$it.key$} & $it.value$ \\
+        $endfor$
+    \end{tabular}
+\end{table}
+$endif$
+
 $if(toc)$
   \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
   \setcounter{secnumdepth}{$toc-depth$}

--- a/inst/rstudio/templates/project/resources/index.Rmd
+++ b/inst/rstudio/templates/project/resources/index.Rmd
@@ -45,6 +45,14 @@ dedication: |
 preface: |
   This is an example of a thesis setup to use the reed thesis document class 
   (for LaTeX) and the R bookdown package, in general.
+abbreviations:
+  ABC: American Broadcasting Company
+  CBS: Colombia Broadcasting System
+  CUS: Computer User Services
+  PBS: Public Broadcasting System
+  NBC: National Broadcasting Company
+# Note that abbreviations in lowercase letters will NOT be automatically capitalized
+# Delete or silence the abbreviations section if you do not want a list of abbreviations
   
 # Specify the location of the bibliography below
 bibliography: bib/thesis.bib

--- a/inst/rstudio/templates/project/resources/template.tex
+++ b/inst/rstudio/templates/project/resources/template.tex
@@ -207,6 +207,18 @@ $if(preface)$
   \end{preface}
 $endif$
 
+$if(abbreviations)$
+\chapter*{List of Abbreviations}
+\begin{table}[h]
+    \centering
+    \begin{tabular}{ll}
+        $for(abbreviations/pairs)$
+        \textbf{$it.key$} & $it.value$ \\
+        $endfor$
+    \end{tabular}
+\end{table}
+$endif$
+
 $if(toc)$
   \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
   \setcounter{secnumdepth}{$toc-depth$}


### PR DESCRIPTION
This change allows an optional "List of Abbreviations" as is allowed and sometimes required in the Reed thesis. It can be removed from the outputted document by deleting or commenting out the corresponding section of YAML. I don't really understand R Markdown, so I edited both copies of the 'template.tex' and 'index.Rmd' files that show up when generating a new project, even though I think one is a copy of the other.

Please let me know if you have any questions!