### PR TITLE
Add an optional list of abbreviations and allow single quotes in prelims

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -34,7 +34,8 @@ output:
 # (e.g., abstract, acknowledgements) below or use code similar to line 25-26 
 # for the .RMD files. If you are NOT producing a PDF, delete or silence
 # lines 25-39 in this YAML header.
-abstract: '`r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`'
+abstract: |
+  `r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`
 # If you'd rather include the preliminary content in files instead of inline
 # like below, use a command like that for the abstract above.  Note that a tab 
 # is needed on the line after the `|`.

--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -45,6 +45,14 @@ dedication: |
 preface: |
   This is an example of a thesis setup to use the reed thesis document class 
   (for LaTeX) and the R bookdown package, in general.
+abbreviations:
+  ABC: American Broadcasting Company
+  CBS: Colombia Broadcasting System
+  CUS: Computer User Services
+  PBS: Public Broadcasting System
+  NBC: National Broadcasting Company
+# Note that abbreviations in lowercase letters will NOT be automatically capitalized
+# Delete or silence the abbreviations section if you do not want a list of abbreviations
   
 # Specify the location of the bibliography below
 bibliography: bib/thesis.bib

--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -207,6 +207,18 @@ $if(preface)$
   \end{preface}
 $endif$
 
+$if(abbreviations)$
+\chapter*{List of Abbreviations}
+\begin{table}[h]
+    \centering
+    \begin{tabular}{ll}
+        $for(abbreviations/pairs)$
+        \textbf{$it.key$} & $it.value$ \\
+        $endfor$
+    \end{tabular}
+\end{table}
+$endif$
+
 $if(toc)$
   \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
   \setcounter{secnumdepth}{$toc-depth$}

--- a/inst/rstudio/templates/project/resources/index.Rmd
+++ b/inst/rstudio/templates/project/resources/index.Rmd
@@ -34,7 +34,8 @@ output:
 # (e.g., abstract, acknowledgements) below or use code similar to line 25-26 
 # for the .RMD files. If you are NOT producing a PDF, delete or silence
 # lines 25-39 in this YAML header.
-abstract: '`r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`'
+abstract: |
+  `r if(knitr:::is_latex_output()) paste(readLines(here::here("prelims", "00-abstract.Rmd")), collapse = "\n  ")`
 # If you'd rather include the preliminary content in files instead of inline
 # like below, use a command like that for the abstract above.  Note that a tab 
 # is needed on the line after the `|`.

--- a/inst/rstudio/templates/project/resources/index.Rmd
+++ b/inst/rstudio/templates/project/resources/index.Rmd
@@ -45,6 +45,14 @@ dedication: |
 preface: |
   This is an example of a thesis setup to use the reed thesis document class 
   (for LaTeX) and the R bookdown package, in general.
+abbreviations:
+  ABC: American Broadcasting Company
+  CBS: Colombia Broadcasting System
+  CUS: Computer User Services
+  PBS: Public Broadcasting System
+  NBC: National Broadcasting Company
+# Note that abbreviations in lowercase letters will NOT be automatically capitalized
+# Delete or silence the abbreviations section if you do not want a list of abbreviations
   
 # Specify the location of the bibliography below
 bibliography: bib/thesis.bib

--- a/inst/rstudio/templates/project/resources/template.tex
+++ b/inst/rstudio/templates/project/resources/template.tex
@@ -207,6 +207,18 @@ $if(preface)$
   \end{preface}
 $endif$
 
+$if(abbreviations)$
+\chapter*{List of Abbreviations}
+\begin{table}[h]
+    \centering
+    \begin{tabular}{ll}
+        $for(abbreviations/pairs)$
+        \textbf{$it.key$} & $it.value$ \\
+        $endfor$
+    \end{tabular}
+\end{table}
+$endif$
+
 $if(toc)$
   \hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$black$endif$}
   \setcounter{secnumdepth}{$toc-depth$}


### PR DESCRIPTION
This PR fixes two issues I've encountered with `thesisdown`.

1. Although the Reed College thesis template provides for a list of abbreviations, `thesisdown` does not. I have added an optional list of abbreviations in the YAML front matter for `index.Rmd` which is inserted into the LaTeX template. If the list of abbreviations is left out of the YAML, nothing different happens to the LaTeX file. These changes have been made for both the "New Project" option and the "New File->R Markdown" option.
2. When using the `thesisdown` template, by default you write your abstract in a different file. However, if that file contains any single quotes/apostrophes (`'`), it will totally break the project. This is because of how R inserts the file into YAML after reading it. I have changed it from single quotes to a "block scalar", which allows any special characters in the `abstract.Rmd` file. This change has also been made for both the "New Project" option and the "New File->R Markdown" option. (closes #184)

I have tested both of these in RStudio when doing `remotes::install_github("Samasaur1/thesisdown")` instead of `ismayc/thesisdown`, and they both worked for both the "New Project" option and the "New File->R Markdown" option.