### PR TITLE
multipage list of abbreviations

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -209,14 +209,11 @@ $endif$
 
 $if(abbreviations)$
 \chapter*{List of Abbreviations}
-\begin{table}[h]
-    \centering
-    \begin{tabular}{ll}
-        $for(abbreviations/pairs)$
-        \textbf{$it.key$} & $it.value$ \\
-        $endfor$
-    \end{tabular}
-\end{table}
+\begin{longtable}{p{.20\textwidth} | p{.80\textwidth}}
+  $for(abbreviations/pairs)$
+    \textbf{$it.key$} & $it.value$ \\
+  $endfor$
+\end{longtable}
 $endif$
 
 $if(toc)$

--- a/inst/rstudio/templates/project/resources/template.tex
+++ b/inst/rstudio/templates/project/resources/template.tex
@@ -209,14 +209,11 @@ $endif$
 
 $if(abbreviations)$
 \chapter*{List of Abbreviations}
-\begin{table}[h]
-    \centering
-    \begin{tabular}{ll}
-        $for(abbreviations/pairs)$
-        \textbf{$it.key$} & $it.value$ \\
-        $endfor$
-    \end{tabular}
-\end{table}
+\begin{longtable}{p{.20\textwidth} | p{.80\textwidth}}
+  $for(abbreviations/pairs)$
+    \textbf{$it.key$} & $it.value$ \\
+  $endfor$
+\end{longtable}
 $endif$
 
 $if(toc)$


### PR DESCRIPTION
Hi Chester,
Currently `template.tex` truncates the list of abbreviations if it does not fit in one page.
I suggest a solution using the `longtable` environment instead, which would allow the list to extend across multiple pages.
This pull request replaces the `table` environment with `longtable`.

This is an example using the current `table environment` ![table](https://github.com/user-attachments/assets/2563a8f5-8fba-4ab5-b3cc-35bfe44d0275)

and this is with `longtable`
![longtable](https://github.com/user-attachments/assets/fe7bd3c6-3d4d-44ab-9316-fcc4aa3ca2f2)

cheers,
Sergi